### PR TITLE
upgrade: migrate docs from nextra v2 to v3 to fix CVE-2026-0969

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -1,15 +1,13 @@
-const withNextra = require('nextra')({
+import nextra from 'nextra'
+
+const withNextra = nextra({
   theme: 'nextra-theme-docs',
   themeConfig: './theme.config.jsx',
   defaultShowCopyCode: true,
-  staticImage: true,
   latex: true,
-  flexsearch: {
-    codeblocks: false
-  }
 })
 
-module.exports = withNextra({
+export default withNextra({
   reactStrictMode: true,
   images: {
     unoptimized: true
@@ -24,4 +22,4 @@ module.exports = withNextra({
       },
     ]
   }
-}) 
+})

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "next": "^14.0.0",
-    "nextra": "^2.13.2",
-    "nextra-theme-docs": "^2.13.2",
+    "nextra": "^3.0.0",
+    "nextra-theme-docs": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/docs/pages/_app.jsx
+++ b/docs/pages/_app.jsx
@@ -1,0 +1,5 @@
+import 'nextra-theme-docs/style.css'
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/docs/pages/_meta.js
+++ b/docs/pages/_meta.js
@@ -1,0 +1,6 @@
+export default {
+  index: { title: 'Introduction' },
+  'getting-started': { title: 'Getting Started' },
+  generators: { title: 'Generators' },
+  sinks: { title: 'Sinks' }
+}

--- a/docs/pages/_meta.json
+++ b/docs/pages/_meta.json
@@ -1,6 +1,0 @@
-{
-    "index": { "title": "Introduction" },
-    "getting-started": { "title": "Getting Started" },
-    "generators": { "title": "Generators"},    
-    "sinks": { "title": "Sinks" }
-}

--- a/docs/pages/sinks/_meta.js
+++ b/docs/pages/sinks/_meta.js
@@ -1,0 +1,8 @@
+export default {
+  index: { title: 'Overview' },
+  csv: { title: 'CSV Sink' },
+  kafka: { title: 'Kafka Sink' },
+  webhook: { title: 'Webhook Sink' },
+  yield: { title: 'Yield Sink' },
+  custom: { title: 'Custom Sink' }
+}

--- a/docs/pages/sinks/_meta.json
+++ b/docs/pages/sinks/_meta.json
@@ -1,8 +1,0 @@
-{
-    "index": { "title": "Overview" },
-    "csv": { "title": "CSV Sink" },    
-    "kafka": { "title": "Kafka Sink" },
-    "webhook": { "title": "Webhook Sink" },
-    "yield": { "title": "Yield Sink" },
-    "custom": { "title": "Custom Sink" }
-  }

--- a/docs/theme.config.jsx
+++ b/docs/theme.config.jsx
@@ -16,11 +16,6 @@ export default {
   footer: {
     text: `GlassGen ${new Date().getFullYear()} © GlassFlow.`
   },
-  useNextSeoProps() {
-    return {
-      titleTemplate: '%s – GlassGen'
-    }
-  },
   head: (
     <>
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -30,5 +25,6 @@ export default {
     </>
   ),
   primaryHue: 210,
-  primarySaturation: 100
+  primarySaturation: 100,
+  titleSuffix: ' – GlassGen'
 } 

--- a/glassgen/config.py
+++ b/glassgen/config.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
@@ -96,7 +96,7 @@ class GlassGenConfig(BaseModel):
 
     def _get_all_field_paths(
         self, schema: Dict[str, Any], prefix: str = ""
-    ) -> list[str]:
+    ) -> List[str]:
         """Get all possible field paths in the schema, including nested ones"""
         paths = []
         for key, value in schema.items():

--- a/glassgen/generator/generators.py
+++ b/glassgen/generator/generators.py
@@ -227,9 +227,9 @@ class GeneratorRegistry:
             GeneratorType.UUID: lambda: str(self._faker.uuid4()),
             GeneratorType.NAME: self._faker.name,
             GeneratorType.TEXT: self._faker.text,
-            GeneratorType.ADDRESS: lambda: self._faker.address()
-            .replace("\n", " ")
-            .strip(),
+            GeneratorType.ADDRESS: lambda: (
+                self._faker.address().replace("\n", " ").strip()
+            ),
             GeneratorType.PHONE_NUMBER: self._faker.phone_number,
             GeneratorType.JOB: self._faker.job,
             GeneratorType.COMPANY: self._faker.company,


### PR DESCRIPTION
   Nextra v2 depended on next-mdx-remote 4.4.1 (vulnerable). Nextra v3
   removes that dependency entirely.

   Migration changes:
   - Bump nextra and nextra-theme-docs to ^3.0.0
   - Convert next.config.js (CJS) to next.config.mjs (ESM, required by nextra v3)
   - Remove staticImage and flexsearch options (no longer needed in v3)
   - Replace _meta.json files with _meta.js (required by nextra v3)
   - Add required pages/_app.jsx with style import
   - Replace removed useNextSeoProps with titleSuffix in theme config