### PR TITLE
Update docs:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 build/
 .pytest_cache/
 .coverage
+uv.lock

--- a/docs/pages/generators.mdx
+++ b/docs/pages/generators.mdx
@@ -11,257 +11,233 @@ GlassGen provides a variety of data generators to create synthetic data. Each ge
 
 ### String Generator
 ```json
-{
-    "field": "$string"
-}
+{ "field": "$string" }
 ```
-Generates a random string.
+Generates a random word.
 
 ### Integer Generator
 ```json
-{
-    "field": "$int"
-}
+{ "field": "$int" }
 ```
 Generates a random integer.
 
 ### Integer Range Generator
 ```json
-{
-    "field": "$intrange(1,100)"
-}
+{ "field": "$intrange(1,100)" }
 ```
-Generates a random integer within the specified range (inclusive).
+Generates a random integer within the specified range (inclusive). Only non-negative integers are supported as parameters.
+
+### Float Generator
+```json
+{ "field": "$float" }
+```
+Generates a random floating-point number with no fixed range (delegates to `faker.pyfloat` — values can be positive, negative, very large, or very small).
+
+### Price Generator
+```json
+{ "field": "$price" }
+```
+Generates a random price rounded to 2 decimal places. Defaults: `min=0.99`, `max=9999.99`. You can specify a custom range and decimal places:
+```json
+{ "field": "$price(1.2, 2.3, 3)" }
+```
+This generates a price between 1.2 and 2.3 with 3 decimal places.
+
+### Boolean Generator
+```json
+{ "field": "$boolean" }
+```
+Generates a random boolean value.
 
 ### Choice Generator
 ```json
-{
-    "field": "$choice(red,blue,green)"
-}
+{ "field": "$choice(red,blue,green)" }
 ```
 Randomly picks one value from the provided list.
 
 ### Datetime Generator
 ```json
-{
-    "field": "$datetime"
-}
+{ "field": "$datetime" }
 ```
-Generates current timestamp in ISO format by default (e.g., "2024-03-15T14:30:45.123456"). You can specify a custom format:
+Generates the current timestamp in ISO format (e.g., `"2024-03-15T14:30:45.123456"`). You can specify a custom format:
 ```json
-{
-    "field": "$datetime(\"%Y-%m-%d %H:%M:%S\")"
-}
+{ "field": "$datetime(\"%Y-%m-%d %H:%M:%S\")" }
 ```
 
 ### Timestamp Generator
 ```json
-{
-    "field": "$timestamp"
-}
+{ "field": "$timestamp" }
 ```
-Generates current Unix timestamp in seconds since epoch (e.g., 1710503445).
+Generates the current Unix timestamp in seconds (e.g., `1710503445`).
 
-### Boolean Generator
+### UUID Generator
 ```json
-{
-    "field": "$boolean"
-}
+{ "field": "$uuid" }
 ```
-Generates a random boolean value.
-
-### Float Generator
-```json
-{
-    "field": "$float"
-}
-```
-Generates a random floating point number.
-
-### Price Generator
-```json
-{
-    "field": "$price"
-}
-```
-Generates a random price value with 2 decimal places (e.g., 99.99). You can also specify custom range and decimal places:
-```json
-{
-    "field": "$price(1.2, 2.3, 3)"
-}
-```
-This generates a price between 1.2 and 2.3 with 3 decimal places.
+Generates a random UUID v4 string. `$uuid` and `$uuid4` are equivalent — both produce UUID v4 values.
 
 ### Greeting Generator
 ```json
-{
-    "field": "$greeting"
-}
+{ "field": "$greeting" }
 ```
-Generates a random greeting (e.g., "Hello", "Hi", "Hey", "Greetings", "Welcome").
+Generates a random greeting: `"Hello"`, `"Hi"`, `"Hey"`, `"Greetings"`, or `"Welcome"`.
 
-### UUID Generators
+### Prefixed ID Generator
+```json
+{ "field": "$prefixed_id(prod, 1, 9999)" }
+```
+Generates a string in the format `prefix_number` (e.g., `prod_42`). Parameters:
+- `prefix` (default: `item`): string prefix
+- `min` (default: `1`): minimum number
+- `max` (default: `1000`): maximum number
+
+```json
+{ "order_id": "$prefixed_id(order, 1000, 9999)" }
+```
+
+### Array Generator
+```json
+{ "field": "$array(email, 3)" }
+```
+Generates a list of values using any other generator. Parameters:
+- `generator_name`: the name of the generator to use for each element
+- `count`: number of elements in the array
+- additional parameters are forwarded to the underlying generator
+
+Examples:
 ```json
 {
-    "field": "$uuid"
+  "tags": "$array(choice(red,blue,green), 2)",
+  "scores": "$array(intrange(0,100), 5)",
+  "emails": "$array(email, 3)"
 }
 ```
-Generates a random UUID.
 
+### Query String Generator
 ```json
-{
-    "field": "$uuid4"
-}
+{ "field": "$query_string" }
 ```
-Generates a random UUID4.
+Generates a URL query string that mimics a Google Analytics 4 event, including fields like `cid`, `sid`, `en` (event name), `dt` (page title), `ul` (language), and `ur` (region). Useful for simulating web analytics data.
+
+---
 
 ## Personal Information
 
 ### Name Generator
 ```json
-{
-    "field": "$name"
-}
+{ "field": "$name" }
 ```
 Generates a random full name.
 
 ### Email Generators
 ```json
-{
-    "field": "$email"
-}
+{ "field": "$email" }
 ```
 Generates a random email address.
 
 ```json
-{
-    "field": "$company_email"
-}
+{ "field": "$company_email" }
 ```
-Generates a random company email.
+Generates a random company email address.
 
 ### Username Generator
 ```json
-{
-    "field": "$user_name"
-}
+{ "field": "$user_name" }
 ```
 Generates a random username.
 
 ### Password Generator
 ```json
-{
-    "field": "$password"
-}
+{ "field": "$password" }
 ```
 Generates a random password.
 
 ### Phone Number Generator
 ```json
-{
-    "field": "$phone_number"
-}
+{ "field": "$phone_number" }
 ```
 Generates a random phone number.
 
 ### SSN Generator
 ```json
-{
-    "field": "$ssn"
-}
+{ "field": "$ssn" }
 ```
 Generates a random Social Security Number.
+
+---
 
 ## Location
 
 ### Country Generator
 ```json
-{
-    "field": "$country"
-}
+{ "field": "$country" }
 ```
 Generates a random country name.
 
 ### City Generator
 ```json
-{
-    "field": "$city"
-}
+{ "field": "$city" }
 ```
 Generates a random city name.
 
 ### Address Generator
 ```json
-{
-    "field": "$address"
-}
+{ "field": "$address" }
 ```
 Generates a random street address.
 
 ### Zipcode Generator
 ```json
-{
-    "field": "$zipcode"
-}
+{ "field": "$zipcode" }
 ```
 Generates a random zip code.
+
+---
 
 ## Business
 
 ### Company Generator
 ```json
-{
-    "field": "$company"
-}
+{ "field": "$company" }
 ```
 Generates a random company name.
 
 ### Job Generator
 ```json
-{
-    "field": "$job"
-}
+{ "field": "$job" }
 ```
 Generates a random job title.
 
 ### URL Generator
 ```json
-{
-    "field": "$url"
-}
+{ "field": "$url" }
 ```
 Generates a random URL.
+
+---
 
 ## Other
 
 ### Text Generator
 ```json
-{
-    "field": "$text"
-}
+{ "field": "$text" }
 ```
 Generates a random text paragraph.
 
 ### IPv4 Generator
 ```json
-{
-    "field": "$ipv4"
-}
+{ "field": "$ipv4" }
 ```
 Generates a random IPv4 address.
 
 ### Currency Name Generator
 ```json
-{
-    "field": "$currency_name"
-}
+{ "field": "$currency_name" }
 ```
 Generates a random currency name.
 
 ### Color Name Generator
 ```json
-{
-    "field": "$color_name"
-}
+{ "field": "$color_name" }
 ```
-Generates a random color name. 
+Generates a random color name.

--- a/docs/pages/getting-started.mdx
+++ b/docs/pages/getting-started.mdx
@@ -51,10 +51,9 @@ Here's a simple example of using GlassGen to generate user data and save it to a
 ```python
 import glassgen
 
-# Define your configuration
 config = {
     "schema": {
-        "name": "$name",        
+        "name": "$name",
         "email": "$email",
         "country": "$country",
         "id": "$uuid",
@@ -70,19 +69,14 @@ config = {
         }
     },
     "generator": {
-        "rps": 1500,  # records per second
-        "num_records": 5000  # total number of records to generate
+        "rps": 1500,
+        "num_records": 5000
     }
 }
 
-# Start the generator
-glassgen.generate(config=config)
+result = glassgen.generate(config=config)
+# result is a dict: {"time_taken_ms": ..., "num_records": ..., "sink": "csv"}
 ```
-
-This will:
-1. Generate 5000 records of user data
-2. Create records at a rate of 1500 records per second
-3. Save the data to a file named `output.csv`
 
 ### Configuration File
 
@@ -92,37 +86,111 @@ You can also load the configuration from a JSON file:
 import glassgen
 import json
 
-# Load configuration from file
 with open("config.json") as f:
     config = json.load(f)
 
-# Start the generator
 glassgen.generate(config=config)
 ```
 
-The configuration file (`config.json`) should follow this structure:
+## CLI
+
+```bash
+glassgen generate-data --config config.json
+```
+
+## generate() Reference
+
+```python
+glassgen.generate(config, schema=None, sink=None)
+```
+
+- `config` (required): A configuration dict or `GlassGenConfig` object.
+- `schema` (optional): A custom `BaseSchema` instance. When provided, the `schema` block in `config` is ignored.
+- `sink` (optional): A `BaseSink` instance or a sink config dict. When provided, the `sink` block in `config` is ignored.
+
+**Return value:**
+- For all sinks except `yield`: returns a `dict` with `time_taken_ms`, `num_records`, and `sink`.
+- For the `yield` sink: returns a **generator** that yields one record at a time. See the [Yield Sink](./sinks/yield) page for details.
+
+## generate_one() Reference
+
+To generate a single record without any sink or generator config, use `generate_one()`:
+
+```python
+import glassgen
+
+record = glassgen.generate_one({
+    "id": "$uuid",
+    "name": "$name",
+    "email": "$email"
+})
+# {"id": "...", "name": "...", "email": "..."}
+```
+
+## Generator Configuration
+
+The `generator` block controls how records are produced:
 
 ```json
 {
-    "schema": {
-        "field1": "$generator_type",
-        "field2": "$generator_type(param1, param2)"
-    },
-    "sink": {
-        "type": "csv|kafka|webhook",
-        "params": {
-            // sink-specific parameters
-        }
-    },
-    "generator": {
-        "rps": 1000,  // records per second
-        "num_records": 5000  // total number of records to generate
-    }
+  "generator": {
+    "rps": 1000,
+    "num_records": 5000,
+    "bulk_size": 5000
+  }
 }
 ```
 
+| Field | Default | Description |
+|---|---|---|
+| `rps` | `0` | Target records per second. `0` means generate as fast as possible with no rate limiting. Values above 2500 also skip rate limiting. |
+| `num_records` | `100` | Total records to generate. Set to `-1` for infinite generation. |
+| `bulk_size` | `5000` | Internal batch size. Tune this to adjust memory usage vs. throughput. |
+
+### Infinite generation
+
+Set `num_records` to `-1` to generate records indefinitely (useful with the yield sink or streaming sinks):
+
+```python
+config = {
+    "schema": {"id": "$uuid", "value": "$int"},
+    "sink": {"type": "yield"},
+    "generator": {"rps": 100, "num_records": -1}
+}
+
+for record in glassgen.generate(config=config):
+    process(record)
+```
+
+## Event Duplication
+
+GlassGen can simulate real-world data streams that contain duplicate events. Configure it under `generator.event_options`:
+
+```json
+{
+  "generator": {
+    "rps": 1000,
+    "num_records": 10000,
+    "event_options": {
+      "duplication": {
+        "enabled": true,
+        "ratio": 0.1,
+        "key_field": "id",
+        "time_window": "1h"
+      }
+    }
+  }
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `enabled` | yes | Turn duplication on or off. |
+| `ratio` | yes | Fraction of records that will be duplicates (0–1). `0.1` means ~10% duplicates. |
+| `key_field` | yes | The schema field used to identify a record for duplication. Must exist in the schema. |
+| `time_window` | no (default `1h`) | How far back to look when picking a record to duplicate. Supports `s`, `m`, `h`, `d` suffixes. |
+
 ## Next Steps
 
-- Learn about [available generators](/generators)
-- Explore [sink options](/sinks)
-- Check out [example configurations](/examples) 
+- Learn about [available generators](./generators)
+- Explore [sink options](./sinks)

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -9,11 +9,11 @@ GlassGen is a flexible synthetic data generation service that allows you to crea
 
 ## Features
 
-- **Multiple Data Generators**: Generate various types of data including personal information, business data, and more. Extend with custom generators using the [custom schema example](/examples/usage_custom_schema)
+- **Multiple Data Generators**: Generate various types of data including personal information, business data, and more
 - **Flexible Configuration**: Configure your data generation using simple JSON schemas
 - **Multiple Output Sinks**: Support for various output sinks including CSV Files, Kafka (Confluent and Aiven), Webhook, and custom sinks
 - **Rate Control**: Fine-tune data generation with configurable records per second (RPS)
-- **Special Operators**: Advanced features like controlled event duplication to simulate real-world scenarios
+- **Event Duplication**: Simulate real-world scenarios with controlled event duplication
 - **Extensible Architecture**: Create custom generators and sinks to meet your specific needs
 
 
@@ -50,7 +50,7 @@ pip install glassgen
 
 ### Using CLI
 ```bash
-glassgen generate --config config.json
+glassgen generate-data --config config.json
 ```
 
 ### Using Python SDK
@@ -96,9 +96,8 @@ glassgen.generate(config=config)
 
 - [Getting Started](./getting-started)
 - [Generators](./generators)
-- [Configuration](./configuration)
-- [Examples](./examples)
+- [Sinks](./sinks)
 
 ## Contributing
 
-We welcome contributions! Please check out our [GitHub repository](https://github.com/glassflow/glassgen) for more information. 
+We welcome contributions! Please check out our [GitHub repository](https://github.com/glassflow/glassgen) for more information.

--- a/docs/pages/sinks/custom.mdx
+++ b/docs/pages/sinks/custom.mdx
@@ -7,35 +7,30 @@ GlassGen allows you to create your own custom sinks by extending the `BaseSink` 
 
 ## Creating a Custom Sink
 
-To create a custom sink, you need to extend the `BaseSink` class and implement three methods:
+Extend `BaseSink` and implement three methods:
 
-1. `publish(self, data)`: Handle a single record
-2. `publish_bulk(self, data)`: Handle multiple records
-3. `close(self)`: Clean up resources when done
-
-Here's a basic example of a custom sink that prints data to the console:
+1. `publish(self, data: dict)`: Handle a single record. **Note:** the GlassGen engine never calls `publish()` directly — it is there for you to call manually if needed.
+2. `publish_bulk(self, data: list)`: Handle a batch of records. **This is the method the engine calls** during generation.
+3. `close(self)`: Clean up any resources when generation is complete.
 
 ```python
 from glassgen.sinks import BaseSink
 
 class PrintSink(BaseSink):
-    def __init__(self, config=None):
-        self.config = config
-    
     def publish(self, data):
         print(data)
-    
+
     def publish_bulk(self, data):
         for item in data:
             print(item)
-    
+
     def close(self):
         pass
 ```
 
 ## Using a Custom Sink
 
-You can use your custom sink by passing it directly to the `generate` function:
+Pass your sink instance to `generate()` via the `sink=` parameter. Custom sinks cannot be configured through the `"sink"` block in a config dict — that block only supports the built-in sink types.
 
 ```python
 import glassgen
@@ -44,17 +39,17 @@ from glassgen.sinks import BaseSink
 class PrintSink(BaseSink):
     def publish(self, data):
         print(data)
-    
+
     def publish_bulk(self, data):
         for item in data:
             print(item)
-    
+
     def close(self):
         pass
 
 config = {
     "schema": {
-        "name": "$name",        
+        "name": "$name",
         "email": "$email",
         "country": "$country",
         "id": "$uuid",
@@ -62,13 +57,13 @@ config = {
         "phone": "$phone_number",
         "job": "$job",
         "company": "$company"
-    },    
+    },
     "generator": {
         "rps": 10,
         "num_records": 100
     }
 }
 
-# Use the custom sink
+# Pass the sink instance directly — do not put it in the config dict
 glassgen.generate(config=config, sink=PrintSink())
 ```

--- a/docs/pages/sinks/webhook.mdx
+++ b/docs/pages/sinks/webhook.mdx
@@ -14,7 +14,6 @@ The Webhook sink sends generated data to HTTP endpoints. It's useful for:
     "params": {
       "url": "https://api.example.com/webhook",
       "headers": {
-        "Content-Type": "application/json",
         "Authorization": "Bearer token"
       },
       "timeout": 30
@@ -26,8 +25,10 @@ The Webhook sink sends generated data to HTTP endpoints. It's useful for:
 ### Configuration Options
 
 - `url` (required): The HTTP endpoint URL
-- `headers` (optional): HTTP headers to include in the request
-- `timeout` (optional): Request timeout in seconds (default: 30)
+- `headers` (optional): Additional HTTP headers to include in the request
+- `timeout` (optional): Request timeout in seconds (default: `30`)
+
+The sink always sends requests with `Content-Type: application/json`. You do not need to include it in `headers`, and it cannot be removed.
 
 ## Examples
 
@@ -74,7 +75,8 @@ The Webhook sink sends generated data to HTTP endpoints. It's useful for:
 
 ## Request Format
 
-### Single Record
+Each record is sent as a JSON object in a single POST request:
+
 ```json
 {
   "id": "550e8400-e29b-41d4-a716-446655440000",
@@ -86,15 +88,13 @@ The Webhook sink sends generated data to HTTP endpoints. It's useful for:
 
 ## Error Handling
 
-The Webhook sink includes built-in error handling:
-- Automatic retries on failed requests
-- Request timeout configuration
-- Detailed error logging
+If the endpoint returns a non-2xx status code, the sink raises an exception and generation stops. There are no automatic retries — each record is attempted once.
 
 ## Security
 
 For secure endpoints, you can configure:
 - HTTPS URLs
-- Authentication headers
+- Authentication headers (Bearer tokens, API keys, etc.)
 - Custom security headers
-- SSL certificate verification 
+
+SSL certificate verification uses the system default (enabled). It is not configurable via the sink.

--- a/docs/pages/sinks/yield.mdx
+++ b/docs/pages/sinks/yield.mdx
@@ -1,36 +1,37 @@
 # Yield Sink
 
-The Yield sink is unique among GlassGen sinks as it doesn't send data to an external destination. Instead, it returns an iterator that you can use to process the generated data directly in your Python code.
+The Yield sink is unique among GlassGen sinks as it doesn't send data to an external destination. Instead, it returns a generator that you can iterate over to process records directly in your Python code.
 
 ## Key Features
 
-- Returns an iterator for direct data processing
+- Returns a generator for direct in-process data access
 - No external dependencies or configuration needed
-- Perfect for in-memory data processing
-- Useful for testing and development
-- Enables custom data processing pipelines
+- Perfect for in-memory data processing, testing, and custom pipelines
 
 ## Configuration
 
-The yield sink has the simplest configuration of all sinks:
-
 ```json
 {
-    "sink": {
-        "type": "yield"
-    }
+  "sink": {
+    "type": "yield"
+  }
 }
 ```
+
+No `params` are required or accepted.
 
 ## Usage Examples
 
 ### Basic Usage
+
+When the sink type is `yield`, `generate()` returns a generator instead of a response dict. Iterate over it to receive one record at a time:
+
 ```python
 import glassgen
 
 config = {
     "schema": {
-        "name": "$name",        
+        "name": "$name",
         "email": "$email",
         "age": "$intrange(18,65)"
     },
@@ -43,10 +44,40 @@ config = {
     }
 }
 
-# Get the iterator
 gen = glassgen.generate(config=config)
 
-# Process the data
 for item in gen:
     print(item)
+    # item is a dict, e.g. {"name": "Jane Doe", "email": "...", "age": 32}
+```
+
+### Accessing Response Metadata
+
+After the generator is exhausted, GlassGen produces a response dict with `time_taken_ms`, `num_records`, and `sink`. A `for` loop silently discards this value. To capture it, use `next()` directly:
+
+```python
+gen = glassgen.generate(config=config)
+
+try:
+    while True:
+        record = next(gen)
+        process(record)
+except StopIteration as e:
+    response = e.value
+    print(f"Generated {response['num_records']} records in {response['time_taken_ms']}ms")
+```
+
+### Infinite Generation
+
+Set `num_records` to `-1` to generate records indefinitely:
+
+```python
+config = {
+    "schema": {"id": "$uuid", "value": "$int"},
+    "sink": {"type": "yield"},
+    "generator": {"rps": 500, "num_records": -1}
+}
+
+for record in glassgen.generate(config=config):
+    process(record)  # runs forever until you break
 ```

--- a/glassgen/config.py
+++ b/glassgen/config.py
@@ -33,7 +33,7 @@ class SinkConfig(BaseModel):
     model_config = {"extra": "forbid"}
 
     # Required params for each sink type
-    _SINK_REQUIRED_PARAMS: ClassVar[Dict[str, list[str]]] = {
+    _SINK_REQUIRED_PARAMS: ClassVar[Dict[str, List[str]]] = {
         "csv": ["path"],
         "kafka": ["bootstrap.servers", "topic"],
         "webhook": ["url"],

--- a/glassgen/interface.py
+++ b/glassgen/interface.py
@@ -51,8 +51,10 @@ def generate(
     sink_type_name = config.sink.type if config.sink else type(sink).__name__
     if sink is None:
         if config.sink is None:
-            raise ConfigError("No sink provided",
-          {"errors": ["Sink must be provided either in config or as parameter"]})
+            raise ConfigError(
+                "No sink provided",
+                {"errors": ["Sink must be provided either in config or as parameter"]},
+            )
         sink = SinkFactory.create(config.sink.type, config.sink.params)
     elif isinstance(sink, dict):
         # Validate sink dict using SinkConfig validator
@@ -62,7 +64,6 @@ def generate(
             sink_type_name = sink_config.type
         except (ValidationError, ConfigError) as e:
             raise ConfigError("Sink validation failed", {"errors": [str(e)]}) from e
-
 
     # Create and run generator
     generator = Generator(config.generator, schema)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,9 +85,11 @@ def test_extra_fields():
     """Test validation of configuration with extra fields"""
     config_with_extra = {
         "schema": {"name": "$name"},
-        "sink": {"type": "csv",
-                 "params": {"path": "/tmp/test.csv"},
-                 "extra_field": "value"},
+        "sink": {
+            "type": "csv",
+            "params": {"path": "/tmp/test.csv"},
+            "extra_field": "value",
+        },
         "generator": {"rps": 100, "num_records": 10},
     }
 
@@ -118,8 +120,10 @@ def test_invalid_sink_type():
     with pytest.raises(ConfigError) as exc_info:
         validate_config(invalid_config)
 
-    assert "csv" in str(exc_info.value.details["errors"][0]).lower() or \
-           "kafka" in str(exc_info.value.details["errors"][0]).lower()
+    assert (
+        "csv" in str(exc_info.value.details["errors"][0]).lower()
+        or "kafka" in str(exc_info.value.details["errors"][0]).lower()
+    )
 
 
 def test_missing_csv_sink_params():
@@ -166,11 +170,12 @@ def test_missing_webhook_sink_params():
 
 def test_yield_sink_no_params():
     """Test that yield sink works without params"""
-    config = validate_config({
-        "schema": {"name": "$name"},
-        "sink": {"type": "yield"},
-        "generator": {"num_records": 10},
-    })
+    config = validate_config(
+        {
+            "schema": {"name": "$name"},
+            "sink": {"type": "yield"},
+            "generator": {"num_records": 10},
+        }
+    )
     assert config.sink.type == "yield"
     assert config.sink.params is None
-


### PR DESCRIPTION
##  `index.mdx`

  - Fixed CLI command: glassgen generate → glassgen generate-data
  - Removed dead links to /configuration and /examples (those pages don't exist)

##  `getting-started.mdx`

  - Fixed CLI command to glassgen generate-data
  - Added generate() reference section documenting all three parameters (config, schema, sink) and the return type difference (dict vs generator)
  - Added generate_one() reference with example
  - Expanded generator config table to document bulk_size and the rps: 0 / rps > 2500 behavior
  - Documented num_records: -1 for infinite generation
  - Added a full Event Duplication section documenting event_options.duplication (this feature was mentioned in the feature list but had zero docs on how to use it)
  - Removed dead link to /examples

## `generators.mdx`

  - Added three previously undocumented generators: $prefixed_id, $array, and $query_string
  - Fixed $price default range description (was implying ~99.99; actual defaults are 0.99–9999.99)
  - Clarified $float range behavior (unbounded, can be negative or very large)
  - Merged $uuid and $uuid4 descriptions — both produce UUID v4; they are identical

##  `sinks/webhook.mdx`

  - Removed false claim of "Automatic retries" — the sink makes one attempt per record with no retry logic
  - Removed "SSL certificate verification" from the configurable security features — it is always on and not configurable
  - Added a note that Content-Type: application/json is always injected automatically

##  `sinks/custom.mdx`

  - Clarified that publish_bulk() is what the engine calls, not publish()
  - Added explicit note that custom sinks must be passed via sink= parameter — they cannot be used via the config "sink" block

##  `sinks/yield.mdx`

  - Documented the return type difference: generate() returns a generator (not a dict) when using yield sink
  - Added a code example showing how to capture the response metadata (time_taken_ms, num_records) after iteration using StopIteration.value
  - Added infinite generation example with num_records: -1