### PR TITLE
Minor fix for disabling duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     <img src="https://github.com/glassflow/glassgen/workflows/Test/badge.svg?labelColor=&color=e69e3a">
   </a>
 <!-- Pytest Coverage Comment:Begin -->
-  <img src=https://img.shields.io/badge/coverage-84%25-green>
+  <img src=https://img.shields.io/badge/coverage-87%25-green>
 <!-- Pytest Coverage Comment:End -->
 </p>
 

--- a/glassgen/generator/generator.py
+++ b/glassgen/generator/generator.py
@@ -20,6 +20,7 @@ class Generator:
         self.duplicate_controller = (
             DuplicateController(self.generator_config)
             if self.generator_config.event_options.duplication
+            and self.generator_config.event_options.duplication.enabled
             else None
         )
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,8 +1,11 @@
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+from glassgen.config import GeneratorConfig
 from glassgen.generator.batch_controller import DynamicBatchController
 from glassgen.generator.duplication import DuplicateController
+from glassgen.generator.generator import Generator
+from glassgen.schema.base import BaseSchema
 
 
 class TestDynamicBatchController:
@@ -162,3 +165,65 @@ class TestDuplicateController:
         assert duplicate["data"]["score"] == 100
         assert duplicate["id"] == "123"
         assert duplicate["email"] == "john@example.com"
+
+
+class TestGenerator:
+    def test_duplicate_controller_is_none_when_duplication_disabled(self):
+        """
+        duplicate_controller must be None when
+        duplication.enabled is False (regression for the bug fix).
+        """
+        mock_duplication = MagicMock()
+        mock_duplication.enabled = False
+
+        mock_event_options = MagicMock()
+        mock_event_options.duplication = mock_duplication
+
+        mock_config = MagicMock(spec=GeneratorConfig)
+        mock_config.rps = 0
+        mock_config.bulk_size = 10
+        mock_config.num_records = 30
+        mock_config.event_options = mock_event_options
+
+        mock_schema = MagicMock(spec=BaseSchema)
+        mock_schema._generate_record.return_value = {"id": "simple"}
+
+        generator = Generator(mock_config, mock_schema)
+
+        assert generator.duplicate_controller is None
+
+        result = list(generator.generate_simple())
+        assert len(result) == 3
+        for batch in result:
+            assert len(batch) == 10
+            for record in batch:
+                assert record == {"id": "simple"}
+
+    def test_duplicate_controller_initialized_when_duplication_enabled(self):
+        """duplicate_controller must be set when duplication.enabled is True."""
+        mock_duplication = MagicMock()
+        mock_duplication.enabled = True
+        mock_duplication.ratio = 0.4
+        mock_duplication.key_field = "id"
+        mock_duplication.time_window = "7s"
+
+        mock_event_options = MagicMock()
+        mock_event_options.duplication = mock_duplication
+
+        mock_config = MagicMock(spec=GeneratorConfig)
+        mock_config.rps = 0
+        mock_config.bulk_size = 10
+        mock_config.num_records = 30
+        mock_config.event_options = mock_event_options
+
+        mock_schema = MagicMock(spec=BaseSchema)
+        mock_schema._generate_record.return_value = {"id": "simple"}
+
+        generator = Generator(mock_config, mock_schema)
+
+        assert generator.duplicate_controller is not None
+
+        result = list(generator.generate_optimized())
+        assert len(result) == 3
+        for batch in result:
+            assert len(batch) == 10


### PR DESCRIPTION
## Summary

- Fix `DuplicateController` being initialised when `duplication.enabled` is `False` — duplicates were generated even when the feature was turned off
- Add `TestGenerator` with two tests covering the disabled and enabled paths
- Test names clearly reflect what is being asserted; `generate_optimized()` is correctly called in the enabled-path test

Closes #21 (supersedes the original PR by @aditypan , which was accidentally closed during a merge conflict resolution).
And fixes https://github.com/glassflow/glassgen/issues/19

## Test plan

- [ ] `test_duplicate_controller_is_none_when_duplication_disabled` — asserts `duplicate_controller is None` when `enabled=False` and verifies `generate_simple` produces correct batches
- [ ] `test_duplicate_controller_initialized_when_duplication_enabled` — asserts `duplicate_controller is not None` when `enabled=True` and verifies `generate_optimized` produces correct batches

🤖 Generated with [Claude Code](https://claude.com/claude-code)