### PR TITLE
feat: add NDJSON file sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ glassgen.generate(config=config)
 GlassGen supports multiple sink types for different output destinations:
 
 - [CSV Sink](#csv-sink) - Write data to CSV files
+- [NDJSON Sink](#ndjson-sink) - Write data to NDJSON files
 - [Kafka Sink](#kafka-sink) - Send data to Kafka topics (supports both Confluent Cloud and Aiven)
 - [Webhook Sink](#webhook-sink) - Send data to HTTP endpoints
 - [Yield Sink](#yield-sink) - Get data as an iterator in Python
@@ -114,6 +115,18 @@ GlassGen supports multiple sink types for different output destinations:
         "type": "csv",
         "params": {
             "path": "output.csv"
+        }
+    }
+}
+```
+
+### NDJSON Sink
+```json
+{
+    "sink": {
+        "type": "ndjson",
+        "params": {
+            "path": "output.ndjson"
         }
     }
 }

--- a/docs/app/sinks/ndjson/page.mdx
+++ b/docs/app/sinks/ndjson/page.mdx
@@ -1,0 +1,89 @@
+---
+title: NDJSON Sink
+---
+
+# NDJSON Sink
+
+The NDJSON sink writes generated data to a [Newline Delimited JSON](https://ndjson.org/) file — one JSON object per line. It's useful for:
+- Streaming data pipelines that process records line by line
+- Log ingestion systems (Elasticsearch, Loki, Fluent Bit)
+- Tools that expect NDJSON input (BigQuery, ClickHouse `JSONEachRow`, jq with `-c`)
+- Preserving nested structures without flattening (unlike the CSV sink)
+
+## Configuration
+
+```json
+{
+  "sink": {
+    "type": "ndjson",
+    "params": {
+      "path": "output.ndjson"
+    }
+  }
+}
+```
+
+### Configuration Options
+
+- `path` (required): The path where the NDJSON file will be written
+
+## Examples
+
+### Basic Usage
+
+```json
+{
+  "schema": {
+    "id": "$uuid",
+    "name": "$name",
+    "email": "$email",
+    "age": "$intrange(18,65)"
+  },
+  "sink": {
+    "type": "ndjson",
+    "params": {
+      "path": "users.ndjson"
+    }
+  },
+  "generator": {
+    "num_records": 1000
+  }
+}
+```
+
+### Nested Objects
+
+Unlike the CSV sink, the NDJSON sink preserves nested structures as-is:
+
+```json
+{
+  "schema": {
+    "event_id": "$uuid",
+    "timestamp": "$timestamp",
+    "user": {
+      "id": "$uuid",
+      "name": "$name",
+      "email": "$email"
+    },
+    "metadata": {
+      "ip": "$ipv4",
+      "country": "$country"
+    }
+  },
+  "sink": {
+    "type": "ndjson",
+    "params": {
+      "path": "events.ndjson"
+    }
+  }
+}
+```
+
+## Output Example
+
+Each line is a valid, self-contained JSON object:
+
+```
+{"id":"550e8400-e29b-41d4-a716-446655440000","name":"John Doe","email":"john.doe@example.com","age":32}
+{"id":"6ba7b810-9dad-11d1-80b4-00c04fd430c8","name":"Jane Smith","email":"jane.smith@example.com","age":28}
+```

--- a/docs/app/sinks/page.mdx
+++ b/docs/app/sinks/page.mdx
@@ -9,6 +9,7 @@ Sinks in GlassGen are destinations where the generated data can be sent. Each si
 ## Available Sinks
 
 - [CSV Sink](./csv) - Write data to CSV files
+- [NDJSON Sink](./ndjson) - Write data to Newline Delimited JSON files
 - [Kafka Sink](./kafka) - Send data to Kafka topics
 - [Webhook Sink](./webhook) - Send data to HTTP endpoints
 - [Yield Sink](./yield) - Get data as an iterator for in-memory processing

--- a/glassgen/sinks/__init__.py
+++ b/glassgen/sinks/__init__.py
@@ -1,12 +1,14 @@
 from glassgen.sinks.base import BaseSink
 from glassgen.sinks.csv_sink import CSVSink
 from glassgen.sinks.kafka_sink import KafkaSink
+from glassgen.sinks.ndjson_sink import NDJSONSink
 from glassgen.sinks.webhook_sink import WebHookSink
 from glassgen.sinks.yield_sink import YieldSink
 
 __all__ = [
     "BaseSink",
     "CSVSink",
+    "NDJSONSink",
     "SinkFactory",
     "KafkaSink",
     "WebHookSink",
@@ -17,6 +19,7 @@ __all__ = [
 class SinkFactory:
     _sinks = {
         "csv": CSVSink,
+        "ndjson": NDJSONSink,
         "webhook": WebHookSink,
         "yield": YieldSink,
         "kafka": KafkaSink,

--- a/glassgen/sinks/ndjson_sink.py
+++ b/glassgen/sinks/ndjson_sink.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field
+
+from glassgen.sinks.base import BaseSink
+
+
+class NDJSONSinkParams(BaseModel):
+    path: str = Field(..., description="Path to the output NDJSON file")
+
+
+class NDJSONSink(BaseSink):
+    def __init__(self, sink_params: Dict[str, Any]):
+        params = NDJSONSinkParams.model_validate(sink_params)
+        self.filepath = Path(params.path)
+        self.file = None
+
+    def _open(self) -> None:
+        if self.file is None:
+            self.file = open(self.filepath, "w")
+
+    def publish(self, data: Dict[str, Any]) -> None:
+        self._open()
+        self.file.write(json.dumps(data) + "\n")
+
+    def publish_bulk(self, data: List[Dict[str, Any]]) -> None:
+        self._open()
+        for record in data:
+            self.file.write(json.dumps(record) + "\n")
+
+    def close(self) -> None:
+        if self.file:
+            self.file.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,13 @@ def temp_csv_file():
 
 
 @pytest.fixture
+def temp_ndjson_file():
+    """Create a temporary NDJSON file for testing"""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".ndjson") as f:
+        return f.name
+
+
+@pytest.fixture
 def mock_webhook():
     """Fixture for mocking webhook requests"""
     with patch("requests.post") as mock_post:

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -92,7 +92,10 @@ def test_ndjson_sink_publish(temp_ndjson_file):
 def test_ndjson_sink_bulk_publish(temp_ndjson_file):
     """Test the NDJSON sink bulk publish method"""
     sink = NDJSONSink({"path": temp_ndjson_file})
-    data = [{"name": "Alice", "age": 25}, {"name": "Bob", "age": 35, "nested": {"x": 1}}]
+    data = [
+        {"name": "Alice", "age": 25},
+        {"name": "Bob", "age": 35, "nested": {"x": 1}},
+    ]
     sink.publish_bulk(data)
     sink.close()
 

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -7,6 +8,7 @@ from glassgen.schema import ConfigSchema
 from glassgen.sinks import (
     BaseSink,
     CSVSink,
+    NDJSONSink,
     SinkFactory,
     WebHookSink,
     YieldSink,
@@ -71,11 +73,63 @@ def test_csv_sink_bulk_publish(temp_csv_file):
     os.unlink(temp_csv_file)
 
 
+def test_ndjson_sink_publish(temp_ndjson_file):
+    """Test the NDJSON sink publish method"""
+    sink = NDJSONSink({"path": temp_ndjson_file})
+    data = {"name": "John", "age": 30}
+    sink.publish(data)
+    sink.close()
+
+    assert os.path.exists(temp_ndjson_file)
+    with open(temp_ndjson_file, "r") as f:
+        lines = f.readlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == data
+
+    os.unlink(temp_ndjson_file)
+
+
+def test_ndjson_sink_bulk_publish(temp_ndjson_file):
+    """Test the NDJSON sink bulk publish method"""
+    sink = NDJSONSink({"path": temp_ndjson_file})
+    data = [{"name": "Alice", "age": 25}, {"name": "Bob", "age": 35, "nested": {"x": 1}}]
+    sink.publish_bulk(data)
+    sink.close()
+
+    assert os.path.exists(temp_ndjson_file)
+    with open(temp_ndjson_file, "r") as f:
+        lines = f.readlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == data[0]
+    assert json.loads(lines[1]) == data[1]
+
+    os.unlink(temp_ndjson_file)
+
+
+def test_ndjson_sink_preserves_nested_structure(temp_ndjson_file):
+    """Test that NDJSON sink preserves nested objects (no flattening)"""
+    sink = NDJSONSink({"path": temp_ndjson_file})
+    data = {"user": {"id": "abc", "score": 99}, "tags": ["a", "b"]}
+    sink.publish(data)
+    sink.close()
+
+    with open(temp_ndjson_file, "r") as f:
+        record = json.loads(f.readline())
+    assert record["user"]["id"] == "abc"
+    assert record["tags"] == ["a", "b"]
+
+    os.unlink(temp_ndjson_file)
+
+
 def test_sink_factory():
     """Test the sink factory"""
     # Test CSV sink creation
     csv_sink = SinkFactory.create("csv", {"path": "test.csv"})
     assert isinstance(csv_sink, CSVSink)
+
+    # Test NDJSON sink creation
+    ndjson_sink = SinkFactory.create("ndjson", {"path": "test.ndjson"})
+    assert isinstance(ndjson_sink, NDJSONSink)
 
     # Test yield sink creation
     yield_sink = SinkFactory.create("yield", {})


### PR DESCRIPTION
## Summary

- Adds `NDJSONSink` that writes generated events as newline-delimited JSON (one record per line)
- Registered as `"ndjson"` in `SinkFactory` — usable via `"type": "ndjson"` in config
- Preserves nested structures as-is (no flattening, unlike the CSV sink)
- Includes docs page and tests with 100% coverage on the new sink

## Usage

```json
{
  "sink": {
    "type": "ndjson",
    "params": { "path": "output.ndjson" }
  }
}
```

## Test plan

- [x] `test_ndjson_sink_publish` — single record written as one JSON line
- [x] `test_ndjson_sink_bulk_publish` — multiple records each on their own line
- [x] `test_ndjson_sink_preserves_nested_structure` — nested objects and arrays are not flattened
- [x] `test_sink_factory` — `SinkFactory.create("ndjson", ...)` returns `NDJSONSink`

🤖 Generated with [Claude Code](https://claude.com/claude-code)